### PR TITLE
INS-1375: Update to work with modern Webpack

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,24 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm test

--- a/lib/bignum.js
+++ b/lib/bignum.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Buffer = require('./buffer');
+var { Buffer } = require('buffer/');
 var jsbn = require('jsbn');
 
 var BigInteger = jsbn.BigInteger;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1,7 +1,0 @@
-'use strict';
-
-if (!Buffer) {
-    global.Buffer = require('buffer/').Buffer;
-}
-
-module.exports = Buffer;

--- a/lib/srp.js
+++ b/lib/srp.js
@@ -2,7 +2,7 @@
 
 const crypto = require('crypto'),
       bignum = require('./bignum'),
-      Buffer = require('./buffer'),
+      { Buffer } = require('buffer/'),
       assert = require('assert');
 
 const zero = bignum(0);
@@ -88,13 +88,15 @@ function getx(params, salt, I, P) {
   assertIsBuffer(salt, "salt (salt)");
   assertIsBuffer(I, "identity (I)");
   assertIsBuffer(P, "password (P)");
-  var hashIP = crypto.createHash(params.hash)
-    .update(Buffer.concat([I, new Buffer(':'), P]))
-    .digest();
-  var hashX = crypto.createHash(params.hash)
-    .update(salt)
-    .update(hashIP)
-    .digest();
+  var hashIP = Buffer.from(
+    crypto.createHash(params.hash)
+      .update(Buffer.concat([I, new Buffer(':'), P]))
+      .digest());
+  var hashX = Buffer.from(
+    crypto.createHash(params.hash)
+      .update(salt)
+      .update(hashIP)
+      .digest());
   return bignum.fromBuffer(hashX);
 };
 
@@ -161,7 +163,7 @@ function genKey(bytes, callback) {
   }
   crypto.randomBytes(bytes, function(err, buf) {
     if (err) return callback (err);
-    return callback(null, buf);
+    return callback(null, Buffer.from(buf));
   });
 };
 
@@ -296,27 +298,33 @@ function server_getS(params, v_num, A_num, b_num, u_num) {
  */
 function getK(params, S_buf) {
   assertIsNBuffer(S_buf, params, "S");
-  return crypto.createHash(params.hash)
+  return Buffer.from(
+    crypto.createHash(params.hash)
       .update(S_buf)
-      .digest();
+      .digest()
+  );
 };
 
 function getM1(params, A_buf, B_buf, S_buf) {
   assertIsNBuffer(A_buf, params, "A");
   assertIsNBuffer(B_buf, params, "B");
   assertIsNBuffer(S_buf, params, "S");
-  return crypto.createHash(params.hash)
-    .update(A_buf).update(B_buf).update(S_buf)
-    .digest();
+  return Buffer.from(
+    crypto.createHash(params.hash)
+      .update(A_buf).update(B_buf).update(S_buf)
+      .digest()
+  );
 }
 
 function getM2(params, A_buf, M_buf, K_buf) {
   assertIsNBuffer(A_buf, params, "A");
   assertIsBuffer(M_buf, "M");
   assertIsBuffer(K_buf, "K");
-  return crypto.createHash(params.hash)
-    .update(A_buf).update(M_buf).update(K_buf)
-    .digest();
+  return Buffer.from(
+    crypto.createHash(params.hash)
+      .update(A_buf).update(M_buf).update(K_buf)
+      .digest()
+  );
 }
 
 function equal(buf1, buf2) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,49 @@
 {
   "name": "srp-js",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "base64-js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
-    "buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
-        "base64-js": "1.2.3",
-        "ieee754": "1.1.11"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
     "diff": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "eyes": {
@@ -30,25 +52,92 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
-    "ieee754": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "vows": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
-      "integrity": "sha1-3QBl8RC6DAptY+hEhRwyCBdtWGc=",
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
-        "diff": "1.0.8",
-        "eyes": "0.1.8"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "vows": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.8.3.tgz",
+      "integrity": "sha512-PVIxa/ovXhrw5gA3mz6M+ZF3PHlqX4tutR2p/y9NWPAaFVKcWBE8b2ktfr0opQM/qFmcOVWKjSCJVjnYOvjXhw==",
+      "dev": true,
+      "requires": {
+        "diff": "^4.0.1",
+        "eyes": "~0.1.6",
+        "glob": "^7.1.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "srp-js",
   "description": "Secure Remote Password (SRP)",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "index.js",
   "scripts": {
     "test": "vows test/test*.js --spec"
@@ -14,10 +14,10 @@
   "licence": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "buffer": "^5.0.0",
-    "jsbn": "^0.1.0"
+    "buffer": "^6.0.3",
+    "jsbn": "^1.1.0"
   },
   "devDependencies": {
-    "vows": "0.7.0"
+    "vows": "0.8.3"
   }
 }

--- a/test/speed.js
+++ b/test/speed.js
@@ -2,7 +2,7 @@
 
 const params = require('../lib/params'),
       srp = require('../lib/srp'),
-      Buffer = require('../lib/buffer'),
+      { Buffer } = require('buffer/'),
       s = new Buffer("salty"),
       I = new Buffer("alice"),
       P = new Buffer("password123"),

--- a/test/test_picl_vectors.js
+++ b/test/test_picl_vectors.js
@@ -3,7 +3,7 @@
 const vows = require('vows'),
       assert = require('assert'),
       bignum = require('../lib/bignum'),
-      Buffer = require('../lib/buffer'),
+      { Buffer } = require('buffer/'),
       srp = require('../lib/srp');
 
 /*

--- a/test/test_rfc_5054.js
+++ b/test/test_rfc_5054.js
@@ -3,7 +3,7 @@
 const vows = require('vows'),
       assert = require('assert'),
       srp = require('../lib/srp'),
-      Buffer = require('../lib/buffer'),
+      { Buffer } = require('buffer/'),
       params = srp.params['1024'];
 
 /*

--- a/test/test_srp.js
+++ b/test/test_srp.js
@@ -4,7 +4,7 @@ const vows = require('vows'),
       assert = require('assert'),
       srp = require('../lib/srp'),
       params = srp.params[4096],
-      Buffer = require('../lib/buffer'),
+      { Buffer } = require('buffer/'),
 
       salt = new Buffer("salty"),
       identity = new Buffer("alice"),


### PR DESCRIPTION
This update imposes using the npm Buffer package regardless of whether we're in Webpack or not.